### PR TITLE
feat(dashboard): add logged-in user dashboard

### DIFF
--- a/app/api/endpoints/dashboard.py
+++ b/app/api/endpoints/dashboard.py
@@ -1,0 +1,20 @@
+from fastapi import APIRouter, HTTPException
+
+from app.services.dashboard import dashboard_service
+
+router = APIRouter(tags=["Dashboard"])
+
+
+@router.get("/{token}/dashboard/data")
+async def dashboard_data(token: str):
+    data = await dashboard_service.get_data(token)
+    if data is None:
+        raise HTTPException(status_code=404, detail="Token not found. Please reconfigure the addon.")
+    return data
+
+
+@router.post("/{token}/dashboard/refresh")
+async def dashboard_refresh(token: str):
+    if not await dashboard_service.refresh(token):
+        raise HTTPException(status_code=404, detail="Token not found. Please reconfigure the addon.")
+    return {"status": "started"}

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter
 
 from .endpoints.announcement import router as announcement_router
 from .endpoints.catalogs import router as catalogs_router
+from .endpoints.dashboard import router as dashboard_router
 from .endpoints.health import router as health_router
 from .endpoints.languages import router as language_router
 from .endpoints.manifest import router as manifest_router
@@ -27,3 +28,4 @@ api_router.include_router(announcement_router)
 api_router.include_router(stats_router)
 api_router.include_router(validation_router)
 api_router.include_router(oauth_router)
+api_router.include_router(dashboard_router)

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -204,6 +204,9 @@ class AuthService:
         response = {"user_id": user_id, "email": email, "exists": exists}
 
         if exists and existing_data:
+            # Token is the user's manifest key; only returned once they've authenticated
+            # here, so the dashboard can read their install without a second login.
+            response["token"] = token
             # Reconstruct UserSettings to ensure defaults are included for old accounts
             raw_settings = existing_data.get("settings", {})
             try:

--- a/app/services/dashboard.py
+++ b/app/services/dashboard.py
@@ -1,0 +1,119 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from app.core.config import settings
+from app.core.settings import resolve_tmdb_api_key
+from app.services.catalog_updater import catalog_updater
+from app.services.context import extract_settings
+from app.services.tmdb.genre import movie_genres, series_genres
+from app.services.tmdb.service import get_tmdb_service
+from app.services.token_store import token_store
+from app.services.user_cache import user_cache
+
+
+class DashboardService:
+    """Read-only view of a user's install plus a manual refresh.
+
+    Everything here is keyed on the manifest token alone (the existing trust model)
+    and deliberately exposes no secrets — no passwords, auth keys, or API keys.
+    """
+
+    async def get_data(self, token: str) -> dict[str, Any] | None:
+        credentials = await token_store.get_user_data(token)
+        if not credentials:
+            return None
+
+        user_settings = extract_settings(credentials)
+        host = settings.HOST_NAME.rstrip("/")
+        tmdb = get_tmdb_service(language=user_settings.language, api_key=resolve_tmdb_api_key(user_settings))
+
+        profiles = {ct: await self._profile_summary(token, ct, tmdb) for ct in ("movie", "series")}
+
+        # Library counts come from the cached collection; null when it hasn't been
+        # built yet (the dashboard's catalog rows trigger that build on first open).
+        library = await user_cache.get_library_items(token)
+        library_stats = (
+            {
+                "total": len(library.all_items()),
+                "loved": len(library.loved),
+                "liked": len(library.liked),
+                "watched": len(library.watched),
+            }
+            if library
+            else None
+        )
+
+        return {
+            "manifest_url": f"{host}/{token}/manifest.json",
+            "settings": {
+                "language": user_settings.language,
+                "popularity": user_settings.popularity,
+                "year_min": user_settings.year_min,
+                "year_max": user_settings.year_max,
+                "sorting_order": user_settings.sorting_order,
+            },
+            "sources": {
+                "active": user_settings.watch_history_source,
+                "trakt": bool(user_settings.trakt_access_token),
+                "simkl": bool(user_settings.simkl_access_token),
+            },
+            "stats": {
+                "library": library_stats,
+                "active_catalogs": sum(1 for c in user_settings.catalogs if c.enabled),
+                "last_refresh": credentials.get("last_updated"),
+            },
+            "profiles": profiles,
+        }
+
+    async def _profile_summary(self, token: str, content_type: str, tmdb: Any) -> dict[str, Any] | None:
+        profile = await user_cache.get_profile(token, content_type)
+        if not profile:
+            return None
+
+        genre_map = movie_genres if content_type == "movie" else series_genres
+        genres = [genre_map[g] for g, _ in profile.get_top_genres(limit=6) if g in genre_map]
+
+        keywords, directors, cast = await asyncio.gather(
+            self._resolve_names(tmdb.get_keyword_details, [k for k, _ in profile.get_top_keywords(limit=6)]),
+            self._resolve_names(tmdb.get_person_details, [d for d, _ in profile.get_top_directors(limit=6)]),
+            self._resolve_names(tmdb.get_person_details, [c for c, _ in profile.get_top_cast(limit=6)]),
+        )
+
+        return {
+            "last_updated": profile.last_updated.isoformat() if profile.last_updated else None,
+            "items": len(profile.processed_items),
+            "genres": genres,
+            "keywords": keywords,
+            "directors": directors,
+            "cast": cast,
+            "eras": [e for e, _ in profile.get_top_eras(limit=4)],
+            "countries": [c for c, _ in profile.get_top_countries(limit=5)],
+        }
+
+    @staticmethod
+    async def _resolve_names(fetch: Callable[[int], Awaitable[dict]], ids: list[int]) -> list[str]:
+        """Resolve TMDB ids to display names, dropping any that fail to look up."""
+
+        async def one(item_id: int) -> str | None:
+            try:
+                return (await fetch(item_id)).get("name")
+            except Exception:
+                return None
+
+        names = await asyncio.gather(*(one(i) for i in ids))
+        return [n for n in names if n]
+
+    async def refresh(self, token: str) -> bool:
+        """Drop the user's cached data so the next request rebuilds fresh, and warm
+        the catalogs in the background. Returns False if the token is unknown."""
+        credentials = await token_store.get_user_data(token)
+        if not credentials:
+            return False
+
+        await user_cache.invalidate_all_user_data(token)
+        await catalog_updater.trigger_update(token, credentials)
+        return True
+
+
+dashboard_service = DashboardService()

--- a/app/static/js/main.js
+++ b/app/static/js/main.js
@@ -7,6 +7,7 @@ import { initializeAuth, setStremioLoggedOutState } from './modules/auth.js';
 import { initializeCatalogList, renderCatalogList } from './modules/catalog.js';
 import { initializeForm, clearErrors, refreshYearSlider } from './modules/form.js';
 import { initializeAccountsUI } from './modules/accounts.js';
+import { initializeDashboard } from './modules/dashboard.js';
 
 const appState = createAppState();
 
@@ -33,7 +34,8 @@ const navItems = {
     login: document.getElementById('nav-login'),
     config: document.getElementById('nav-config'),
     catalogs: document.getElementById('nav-catalogs'),
-    install: document.getElementById('nav-install')
+    install: document.getElementById('nav-install'),
+    dashboard: document.getElementById('nav-dashboard')
 };
 
 const sections = {
@@ -42,7 +44,8 @@ const sections = {
     config: document.getElementById('sect-config'),
     catalogs: document.getElementById('sect-catalogs'),
     install: document.getElementById('sect-install'),
-    success: document.getElementById('sect-success')
+    success: document.getElementById('sect-success'),
+    dashboard: document.getElementById('sect-dashboard')
 };
 
 // Main scroll container
@@ -141,6 +144,9 @@ document.addEventListener('DOMContentLoaded', () => {
             updateYearSlider: refreshYearSlider
         }
     );
+
+    // Initialize the Dashboard nav section
+    initializeDashboard({ switchSection }, appState);
 
     // Initialize mobile navigation
     initializeMobileNav();

--- a/app/static/js/modules/auth.js
+++ b/app/static/js/modules/auth.js
@@ -252,6 +252,14 @@ async function fetchStremioIdentity(authKey) {
     const data = await res.json();
     const userDisplay = data.email || data.user_id;
 
+    // Remember whether this account already has an install (and its token) so the
+    // Dashboard section can load it without a second login.
+    if (appState) {
+        appState.auth.token = data.token || '';
+        appState.auth.hasInstall = !!data.exists;
+        appState.auth.userDisplay = userDisplay;
+    }
+
     // Show user profile in sidebar
     showUserProfile(userDisplay);
 

--- a/app/static/js/modules/dashboard.js
+++ b/app/static/js/modules/dashboard.js
@@ -1,0 +1,443 @@
+// Dashboard — a separate nav section (gated behind login) showing the user's install:
+// manifest URL, install links, KPIs, catalog previews, and taste profile. Loaded on
+// nav click. Account deletion lives in the Save & Install flow, not here.
+
+let appState = null;
+let switchSection = null;
+let dashboardData = null;
+let activeContentType = 'movie';
+
+const $ = (id) => document.getElementById(id);
+const show = (el) => el && el.classList.remove('hidden');
+const hide = (el) => el && el.classList.add('hidden');
+
+const POPULARITY_LABELS = { mainstream: 'Mainstream', balanced: 'Balanced', gems: 'Hidden Gems', all: 'All' };
+const SORTING_LABELS = { default: 'Default', movies_first: 'Movies first', series_first: 'Series first' };
+
+const STATE_BLOCKS = ['dashLoggedOut', 'dashNoInstall', 'dashLoading', 'dashError', 'dashContent'];
+
+export function initializeDashboard(actions, state) {
+    appState = state;
+    switchSection = actions.switchSection;
+
+    const nav = $('nav-dashboard');
+    if (nav) nav.addEventListener('click', render);
+
+    const loginBtn = $('dashLoginBtn');
+    if (loginBtn) loginBtn.addEventListener('click', () => switchSection && switchSection('login'));
+
+    wireCopy();
+    wireRefresh();
+    wireProfileTabs();
+    wireCatalogFilter();
+}
+
+function setState(visibleId) {
+    STATE_BLOCKS.forEach((id) => hide($(id)));
+    show($(visibleId));
+}
+
+async function render() {
+    if (!appState || !appState.auth.loggedIn) {
+        setState('dashLoggedOut');
+        return;
+    }
+    if (!appState.auth.hasInstall || !appState.auth.token) {
+        setState('dashNoInstall');
+        return;
+    }
+    setState('dashLoading');
+    try {
+        const res = await fetch(`/${appState.auth.token}/dashboard/data`);
+        if (!res.ok) {
+            const err = await res.json().catch(() => ({}));
+            throw new Error(err.detail || 'Could not load your dashboard.');
+        }
+        dashboardData = await res.json();
+        renderContent();
+        setState('dashContent');
+    } catch (e) {
+        $('dashError').textContent = e.message;
+        setState('dashError');
+    }
+}
+
+function chip(text) {
+    const span = document.createElement('span');
+    span.className = 'inline-block text-xs bg-neutral-800 border border-slate-700 rounded-full px-3 py-1 text-slate-200';
+    span.textContent = text;
+    return span;
+}
+
+function chipRow(label, values) {
+    if (!values || !values.length) return null;
+    const wrap = document.createElement('div');
+    wrap.className = 'mb-4';
+    const heading = document.createElement('p');
+    heading.className = 'text-xs text-slate-500 mb-2';
+    heading.textContent = label;
+    wrap.appendChild(heading);
+    const row = document.createElement('div');
+    row.className = 'flex flex-wrap gap-2';
+    values.forEach((v, idx) => {
+        const c = chip(v);
+        c.classList.add('dash-chip');
+        c.style.animationDelay = `${idx * 40}ms`;
+        row.appendChild(c);
+    });
+    wrap.appendChild(row);
+    return wrap;
+}
+
+function renderSources(sources) {
+    const row = $('dashSources');
+    row.innerHTML = '';
+    const items = [
+        { label: `Source: ${sources.active}`, on: true },
+        { label: 'Trakt', on: sources.trakt },
+        { label: 'Simkl', on: sources.simkl },
+    ];
+    items.forEach(({ label, on }) => {
+        const span = document.createElement('span');
+        span.className = on
+            ? 'text-xs rounded-full px-3 py-1 bg-emerald-500/10 text-emerald-300 border border-emerald-500/20'
+            : 'text-xs rounded-full px-3 py-1 bg-neutral-800 text-slate-500 border border-slate-700';
+        span.textContent = on ? `${label} ✓` : label;
+        row.appendChild(span);
+    });
+}
+
+function renderSettings(s) {
+    const grid = $('dashSettings');
+    grid.innerHTML = '';
+    const fields = [
+        ['Discovery', POPULARITY_LABELS[s.popularity] || s.popularity],
+        ['Language', s.language],
+        ['Years', `${s.year_min}–${s.year_max}`],
+        ['Sorting', SORTING_LABELS[s.sorting_order] || s.sorting_order],
+    ];
+    fields.forEach(([label, value]) => {
+        const cell = document.createElement('div');
+        cell.innerHTML = `<p class="text-xs text-slate-500 mb-1">${label}</p><p class="text-slate-200">${value}</p>`;
+        grid.appendChild(cell);
+    });
+}
+
+const PREVIEW_ITEM_LIMIT = 14;
+
+// Render each served catalog as a horizontal poster strip, fetched lazily as it
+// scrolls into view so opening the dashboard doesn't fan out every catalog at once.
+async function loadCatalogRows() {
+    const container = $('dashCatalogRows');
+    container.innerHTML = '<p class="text-sm text-slate-500">Loading catalogs…</p>';
+
+    let manifest;
+    try {
+        const res = await fetch(`/${appState.auth.token}/manifest.json`);
+        if (!res.ok) throw new Error('manifest');
+        manifest = await res.json();
+    } catch (e) {
+        container.innerHTML = '<p class="text-sm text-red-400">Could not load your catalogs.</p>';
+        return;
+    }
+
+    const catalogs = manifest.catalogs || [];
+    container.innerHTML = '';
+    if (!catalogs.length) {
+        container.innerHTML = '<p class="text-sm text-slate-500">No catalogs enabled.</p>';
+        return;
+    }
+
+    const observer = new IntersectionObserver(
+        (entries, obs) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    obs.unobserve(entry.target);
+                    fetchCatalogRow(entry.target);
+                }
+            });
+        },
+        { rootMargin: '300px' }
+    );
+
+    catalogs.forEach((cat) => {
+        const row = buildCatalogRow(cat);
+        container.appendChild(row);
+        observer.observe(row);
+    });
+
+    setCatalogFilter('all');
+}
+
+function buildCatalogRow(cat) {
+    const row = document.createElement('div');
+    row.dataset.type = cat.type;
+    row.dataset.id = cat.id;
+
+    const header = document.createElement('div');
+    header.className = 'flex items-baseline justify-between mb-2';
+    header.innerHTML =
+        `<h4 class="text-sm font-medium text-slate-200 truncate">${cat.name || cat.id}</h4>` +
+        `<span class="text-xs text-slate-600 ml-3 flex-shrink-0"><span class="dash-row-count"></span>${cat.type === 'series' ? 'Series' : 'Movies'}</span>`;
+    row.appendChild(header);
+
+    const strip = document.createElement('div');
+    strip.className = 'dash-strip flex gap-3 overflow-x-auto pb-2';
+    for (let i = 0; i < 6; i++) strip.appendChild(skeletonCard());
+    row.appendChild(strip);
+
+    return row;
+}
+
+function skeletonCard() {
+    const card = document.createElement('div');
+    card.className = 'flex-shrink-0 w-[110px]';
+    card.innerHTML =
+        '<div class="w-[110px] h-[165px] rounded-lg bg-neutral-800 animate-pulse"></div>' +
+        '<div class="mt-1.5 h-3 w-20 rounded bg-neutral-800 animate-pulse"></div>';
+    return card;
+}
+
+async function fetchCatalogRow(row) {
+    const strip = row.querySelector('.dash-strip');
+    const countEl = row.querySelector('.dash-row-count');
+    const { type, id } = row.dataset;
+    try {
+        const res = await fetch(`/${appState.auth.token}/catalog/${type}/${encodeURIComponent(id)}.json`);
+        if (!res.ok) throw new Error('catalog');
+        const data = await res.json();
+        const all = data.metas || [];
+        const metas = all.slice(0, PREVIEW_ITEM_LIMIT);
+        strip.innerHTML = '';
+        if (!metas.length) {
+            strip.innerHTML = '<p class="text-xs text-slate-600">No items yet — open it in Stremio to build it.</p>';
+            return;
+        }
+        if (countEl) countEl.textContent = `${all.length} · `;
+        metas.forEach((m) => strip.appendChild(posterCard(m, type)));
+    } catch (e) {
+        strip.innerHTML = '<p class="text-xs text-red-400">Could not load items.</p>';
+    }
+}
+
+function posterCard(meta, type) {
+    // IMDb-id items deep-link to their Stremio detail page; TMDB-only items aren't linkable.
+    const linkable = typeof meta.id === 'string' && meta.id.startsWith('tt');
+    const card = document.createElement(linkable ? 'a' : 'div');
+    card.className = 'dash-poster-card flex-shrink-0 w-[110px] group';
+    if (linkable) {
+        card.href = `https://web.stremio.com/#/detail/${type}/${meta.id}`;
+        card.target = '_blank';
+        card.rel = 'noopener';
+        card.title = `Open "${meta.name || ''}" in Stremio`;
+    }
+
+    const year = meta.releaseInfo ? ` · ${meta.releaseInfo}` : '';
+    const rating = meta.imdbRating && meta.imdbRating !== 'None' ? `★ ${meta.imdbRating}` : '';
+
+    if (meta.poster) {
+        const img = document.createElement('img');
+        img.src = meta.poster;
+        img.alt = meta.name || '';
+        img.loading = 'lazy';
+        img.className =
+            'dash-poster-img w-[110px] h-[165px] object-cover rounded-lg bg-neutral-800 ring-1 ring-white/5 group-hover:ring-white/30';
+        img.onerror = () => { img.style.visibility = 'hidden'; };
+        card.appendChild(img);
+    } else {
+        const ph = document.createElement('div');
+        ph.className = 'w-[110px] h-[165px] rounded-lg bg-neutral-800 ring-1 ring-white/5';
+        card.appendChild(ph);
+    }
+
+    const title = document.createElement('p');
+    title.className = 'mt-1.5 text-xs text-slate-300 truncate group-hover:text-white transition-colors';
+    title.title = meta.name || '';
+    title.textContent = meta.name || '';
+    card.appendChild(title);
+
+    if (rating || year) {
+        const sub = document.createElement('p');
+        sub.className = 'text-[11px] text-slate-600 truncate';
+        sub.textContent = `${rating}${year}`.trim();
+        card.appendChild(sub);
+    }
+
+    return card;
+}
+
+function setCatalogFilter(filter) {
+    document.querySelectorAll('.dashCatFilter').forEach((b) => {
+        const active = b.dataset.filter === filter;
+        b.classList.toggle('bg-white', active);
+        b.classList.toggle('text-black', active);
+        b.classList.toggle('text-slate-300', !active);
+    });
+    document.querySelectorAll('#dashCatalogRows [data-type]').forEach((row) => {
+        row.classList.toggle('hidden', filter !== 'all' && row.dataset.type !== filter);
+    });
+}
+
+function wireCatalogFilter() {
+    document.querySelectorAll('.dashCatFilter').forEach((b) =>
+        b.addEventListener('click', () => setCatalogFilter(b.dataset.filter))
+    );
+}
+
+function renderProfile() {
+    const body = $('dashProfileBody');
+    body.innerHTML = '';
+
+    document.querySelectorAll('.dashProfileTab').forEach((tab) => {
+        const isActive = tab.dataset.ct === activeContentType;
+        tab.classList.toggle('bg-white', isActive);
+        tab.classList.toggle('text-black', isActive);
+        tab.classList.toggle('text-slate-300', !isActive);
+    });
+
+    const p = dashboardData.profiles[activeContentType];
+    if (!p) {
+        body.innerHTML = `<p class="text-sm text-slate-500">No ${activeContentType} profile yet — it builds after your first catalog request.</p>`;
+        return;
+    }
+
+    const meta = document.createElement('p');
+    meta.className = 'text-xs text-slate-500 mb-4';
+    const when = p.last_updated ? new Date(p.last_updated).toLocaleDateString() : '—';
+    meta.textContent = `Built from ${p.items} item(s) · updated ${when}`;
+    body.appendChild(meta);
+
+    const rows = [
+        chipRow('Top genres', p.genres),
+        chipRow('Directors', p.directors),
+        chipRow('Cast', p.cast),
+        chipRow('Keywords', p.keywords),
+        chipRow('Eras', p.eras),
+        chipRow('Countries', p.countries),
+    ].filter(Boolean);
+
+    if (!rows.length) {
+        body.innerHTML += `<p class="text-sm text-slate-500">Not enough signal yet.</p>`;
+        return;
+    }
+    rows.forEach((r) => body.appendChild(r));
+}
+
+function renderContent() {
+    $('dashManifestUrl').textContent = dashboardData.manifest_url;
+    renderIdentity();
+    renderInstallLink();
+    renderKpis(dashboardData.stats);
+    renderSources(dashboardData.sources);
+    renderSettings(dashboardData.settings);
+    renderProfile();
+    loadCatalogRows();
+}
+
+function renderIdentity() {
+    const name = (appState && appState.auth.userDisplay) || '';
+    $('dashEmail').textContent = name || 'Your account';
+    $('dashAvatar').textContent = name ? name.replace(/@.*/, '').slice(0, 2).toUpperCase() : 'W';
+
+    const greeting = $('dashGreeting');
+    if (greeting) {
+        const h = new Date().getHours();
+        const part = h < 12 ? 'Good morning' : h < 18 ? 'Good afternoon' : 'Good evening';
+        greeting.textContent = `${part}, welcome back`;
+    }
+}
+
+// Ease-out count-up; leaves non-numeric values (e.g. "—") untouched.
+function animateCount(el, target) {
+    if (!el) return;
+    if (typeof target !== 'number' || isNaN(target)) {
+        el.textContent = target == null ? '—' : target;
+        return;
+    }
+    const duration = 750;
+    const start = performance.now();
+    function tick(now) {
+        const p = Math.min(1, (now - start) / duration);
+        el.textContent = Math.round(target * (1 - Math.pow(1 - p, 3)));
+        if (p < 1) requestAnimationFrame(tick);
+    }
+    requestAnimationFrame(tick);
+}
+
+function renderInstallLink() {
+    const url = dashboardData.manifest_url || '';
+    // stremio:// deep link opens the install dialog in the Stremio app; web link installs via web.stremio.com.
+    $('dashInstallBtn').href = url.replace(/^https?:\/\//, 'stremio://');
+    $('dashInstallWebBtn').href = `https://web.stremio.com/#/addons?addon=${encodeURIComponent(url)}`;
+}
+
+function renderKpis(stats) {
+    const lib = stats && stats.library;
+    animateCount($('dashKpiTotal'), lib ? lib.total : '—');
+    animateCount($('dashKpiLoved'), lib ? lib.loved : '—');
+    animateCount($('dashKpiLiked'), lib ? lib.liked : '—');
+    animateCount($('dashKpiWatched'), lib ? lib.watched : '—');
+    animateCount($('dashKpiCatalogs'), stats && stats.active_catalogs != null ? stats.active_catalogs : '—');
+
+    const lastEl = $('dashLastRefresh');
+    if (stats && stats.last_refresh) {
+        const d = new Date(stats.last_refresh);
+        lastEl.textContent = `Last refreshed ${isNaN(d.getTime()) ? stats.last_refresh : d.toLocaleString()}`;
+        lastEl.classList.remove('hidden');
+    } else {
+        lastEl.classList.add('hidden');
+    }
+}
+
+function wireCopy() {
+    const btn = $('dashCopyBtn');
+    if (!btn) return;
+    btn.addEventListener('click', async () => {
+        if (!dashboardData) return;
+        try {
+            await navigator.clipboard.writeText(dashboardData.manifest_url);
+            const original = btn.textContent;
+            btn.textContent = 'Copied ✓';
+            setTimeout(() => (btn.textContent = original), 1500);
+        } catch (e) {
+            /* clipboard blocked — no-op */
+        }
+    });
+}
+
+function wireRefresh() {
+    const btn = $('dashRefreshBtn');
+    if (!btn) return;
+    btn.addEventListener('click', async () => {
+        if (!appState || !appState.auth.token) return;
+        const msg = $('dashRefreshMsg');
+        btn.disabled = true;
+        btn.classList.add('opacity-50', 'cursor-not-allowed');
+        const original = btn.textContent;
+        btn.textContent = 'Refreshing…';
+        try {
+            const res = await fetch(`/${appState.auth.token}/dashboard/refresh`, { method: 'POST' });
+            if (!res.ok) throw new Error('Refresh failed. Please try again.');
+            msg.textContent = 'Refresh started — your catalogs will rebuild on the next open in Stremio.';
+            msg.classList.remove('hidden', 'text-red-400');
+            msg.classList.add('text-emerald-300');
+        } catch (e) {
+            msg.textContent = e.message;
+            msg.classList.remove('hidden', 'text-emerald-300');
+            msg.classList.add('text-red-400');
+        } finally {
+            btn.disabled = false;
+            btn.classList.remove('opacity-50', 'cursor-not-allowed');
+            btn.textContent = original;
+        }
+    });
+}
+
+function wireProfileTabs() {
+    document.querySelectorAll('.dashProfileTab').forEach((tab) => {
+        tab.addEventListener('click', () => {
+            activeContentType = tab.dataset.ct;
+            if (dashboardData) renderProfile();
+        });
+    });
+}

--- a/app/static/js/state.js
+++ b/app/static/js/state.js
@@ -9,7 +9,9 @@ export function createAppState() {
         auth: {
             loggedIn: false,
             authKey: '',
-            userDisplay: null
+            userDisplay: null,
+            token: '',
+            hasInstall: false
         },
         ui: {
             currentSection: 'welcome'
@@ -22,6 +24,8 @@ export function resetAppState(state) {
     state.auth.loggedIn = false;
     state.auth.authKey = '';
     state.auth.userDisplay = null;
+    state.auth.token = '';
+    state.auth.hasInstall = false;
     state.ui.currentSection = 'welcome';
     state.catalogs = cloneDefaultCatalogs();
 }

--- a/app/templates/components/section_dashboard.html
+++ b/app/templates/components/section_dashboard.html
@@ -1,0 +1,218 @@
+<!-- Dashboard Section -->
+<style>
+    @keyframes dashRise {
+        from { opacity: 0; transform: translateY(18px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes dashPop {
+        from { opacity: 0; transform: scale(.82); }
+        to   { opacity: 1; transform: scale(1); }
+    }
+    @keyframes dashFloat {
+        0%, 100% { transform: translate(0, 0); }
+        50%      { transform: translate(10px, -12px); }
+    }
+
+    #dashContent > * { animation: dashRise .55s cubic-bezier(.16, 1, .3, 1) both; }
+    #dashContent > *:nth-child(1) { animation-delay: .04s; }
+    #dashContent > *:nth-child(2) { animation-delay: .11s; }
+    #dashContent > *:nth-child(3) { animation-delay: .18s; }
+    #dashContent > *:nth-child(4) { animation-delay: .25s; }
+    #dashContent > *:nth-child(5) { animation-delay: .32s; }
+
+    .dash-card {
+        position: relative;
+        background:
+            radial-gradient(120% 120% at 0% 0%, rgba(255, 255, 255, .05), transparent 40%),
+            rgba(23, 23, 23, .55);
+        border: 1px solid rgba(255, 255, 255, .08);
+        border-radius: 1.25rem;
+        backdrop-filter: blur(10px);
+        transition: border-color .3s ease, transform .3s ease;
+    }
+    .dash-card:hover { border-color: rgba(255, 255, 255, .16); }
+
+    .dash-blob {
+        position: absolute; border-radius: 9999px; filter: blur(48px);
+        pointer-events: none; animation: dashFloat 9s ease-in-out infinite;
+    }
+
+    .dash-gradient-text {
+        background: linear-gradient(92deg, #ffffff 10%, #d8b4fe 55%, #818cf8 95%);
+        -webkit-background-clip: text; background-clip: text; color: transparent;
+    }
+
+    .dash-kpi { transition: transform .25s ease, border-color .25s ease, background-color .25s ease; }
+    .dash-kpi:hover { transform: translateY(-4px); border-color: rgba(255, 255, 255, .18); }
+
+    .dash-chip { animation: dashPop .35s cubic-bezier(.2, 1.3, .4, 1) both; }
+
+    .dash-poster-card { transition: transform .25s ease; }
+    .dash-poster-card:hover { transform: translateY(-6px); z-index: 5; }
+    .dash-poster-card:hover .dash-poster-img { box-shadow: 0 12px 30px -8px rgba(0, 0, 0, .7); }
+    .dash-poster-img { transition: box-shadow .25s ease, transform .25s ease; }
+
+    .dash-strip::-webkit-scrollbar { height: 6px; }
+    .dash-strip::-webkit-scrollbar-thumb { background: #3f3f46; border-radius: 4px; }
+
+    @media (prefers-reduced-motion: reduce) {
+        #dashContent > *, .dash-chip, .dash-blob { animation: none; }
+        .dash-kpi:hover, .dash-poster-card:hover { transform: none; }
+    }
+</style>
+
+<section id="sect-dashboard" class="hidden animate-fade-in">
+    <div class="mb-8">
+        <h2 class="text-3xl font-bold dash-gradient-text mb-2">Dashboard</h2>
+        <p class="text-slate-400 text-sm">Your install at a glance — catalogs, taste profile, and a manual refresh.</p>
+    </div>
+
+    <!-- Logged-out (nav is open; gated by content) -->
+    <div id="dashLoggedOut" class="hidden dash-card p-8 text-center">
+        <p class="text-slate-300 mb-4">Log in with your Stremio account to view your dashboard.</p>
+        <button type="button" id="dashLoginBtn"
+            class="bg-white text-black font-medium rounded-xl px-5 py-2.5 hover:bg-slate-200 transition-colors">Go to
+            login</button>
+    </div>
+
+    <!-- Logged in but no install yet -->
+    <div id="dashNoInstall" class="hidden dash-card p-8 text-center">
+        <p class="text-slate-300">You haven't installed Watchly yet. Finish the Save &amp; Install step to see your
+            dashboard.</p>
+    </div>
+
+    <!-- Loading -->
+    <div id="dashLoading" class="hidden flex items-center gap-3 text-sm text-slate-400 py-10 justify-center">
+        <div class="w-5 h-5 border-2 border-white/20 border-t-white rounded-full animate-spin"></div>
+        Loading your dashboard…
+    </div>
+    <p id="dashError" class="hidden text-sm text-red-400 py-6 text-center"></p>
+
+    <!-- Content -->
+    <div id="dashContent" class="hidden space-y-5">
+        <!-- Hero: identity, manifest, install -->
+        <div class="dash-card p-6 sm:p-7 overflow-hidden">
+            <div class="dash-blob -top-24 -right-12 w-60 h-60 bg-pink-500/15"></div>
+            <div class="relative">
+                <div class="flex items-start justify-between gap-4 mb-6">
+                    <div class="flex items-center gap-4 min-w-0">
+                        <div class="p-[2px] rounded-full bg-gradient-to-br from-pink-400 via-purple-400 to-sky-400 flex-shrink-0 shadow-lg shadow-purple-900/20">
+                            <div id="dashAvatar"
+                                class="w-12 h-12 rounded-full bg-neutral-950 text-white flex items-center justify-center font-bold text-base"></div>
+                        </div>
+                        <div class="min-w-0">
+                            <p id="dashGreeting" class="text-xs text-slate-400"></p>
+                            <p id="dashEmail" class="text-base text-white font-semibold truncate"></p>
+                        </div>
+                    </div>
+                    <button type="button" id="dashRefreshBtn"
+                        class="group flex items-center gap-2 text-sm border border-slate-700 rounded-xl px-3.5 py-2 text-slate-300 hover:text-white hover:bg-white/5 transition-colors flex-shrink-0">
+                        <svg id="dashRefreshIcon" class="w-4 h-4 group-hover:rotate-180 transition-transform duration-500"
+                            fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15">
+                            </path>
+                        </svg>
+                        <span class="hidden sm:inline">Refresh</span>
+                    </button>
+                </div>
+
+                <p class="text-[11px] font-medium text-slate-500 uppercase tracking-wider mb-2">Manifest URL</p>
+                <div class="flex items-center gap-2 mb-4">
+                    <code id="dashManifestUrl"
+                        class="text-sm text-slate-200 break-all font-mono bg-black/40 ring-1 ring-white/10 px-3 py-2 rounded-lg flex-1 min-w-0"></code>
+                    <button type="button" id="dashCopyBtn"
+                        class="text-sm border border-slate-700 rounded-xl px-4 py-2 text-slate-300 hover:text-white hover:bg-white/5 transition-colors flex-shrink-0">Copy</button>
+                </div>
+
+                <div class="flex flex-col sm:flex-row gap-3">
+                    <a id="dashInstallBtn" href="#"
+                        class="flex-1 text-center bg-gradient-to-r from-stremio to-purple-600 hover:from-stremio-hover hover:to-purple-500 text-white font-semibold rounded-xl px-4 py-3 transition-all hover:-translate-y-0.5 hover:shadow-lg hover:shadow-purple-900/30">Open
+                        in Stremio</a>
+                    <a id="dashInstallWebBtn" href="#" target="_blank" rel="noopener"
+                        class="flex-1 text-center bg-white/5 hover:bg-white/10 text-white font-medium rounded-xl px-4 py-3 transition-colors border border-white/10">Install
+                        on web</a>
+                </div>
+
+                <div id="dashSources" class="flex flex-wrap items-center gap-2 mt-4"></div>
+                <p id="dashLastRefresh" class="text-xs text-slate-500 mt-3 hidden"></p>
+                <p id="dashRefreshMsg" class="text-xs mt-2 hidden"></p>
+            </div>
+        </div>
+
+        <!-- KPI cards -->
+        <div class="grid grid-cols-2 sm:grid-cols-5 gap-3">
+            <div class="dash-card dash-kpi p-4">
+                <div class="flex items-center gap-2 mb-2 text-slate-400">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"></path></svg>
+                    <span class="text-xs">Library</span>
+                </div>
+                <p id="dashKpiTotal" class="text-2xl font-bold text-white tabular-nums">—</p>
+            </div>
+            <div class="dash-card dash-kpi p-4">
+                <div class="flex items-center gap-2 mb-2 text-rose-300/80">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M11.645 20.91l-.007-.003-.022-.012a15.247 15.247 0 01-.383-.218 25.18 25.18 0 01-4.244-3.17C4.688 15.36 2.25 12.174 2.25 8.25 2.25 5.322 4.714 3 7.688 3A5.5 5.5 0 0112 5.052 5.5 5.5 0 0116.313 3c2.973 0 5.437 2.322 5.437 5.25 0 3.925-2.438 7.111-4.739 9.256a25.175 25.175 0 01-4.244 3.17 15.247 15.247 0 01-.383.219l-.022.012-.007.004-.003.001a.752.752 0 01-.704 0l-.003-.001z"></path></svg>
+                    <span class="text-xs">Loved</span>
+                </div>
+                <p id="dashKpiLoved" class="text-2xl font-bold text-rose-300 tabular-nums">—</p>
+            </div>
+            <div class="dash-card dash-kpi p-4">
+                <div class="flex items-center gap-2 mb-2 text-amber-300/80">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.007 5.404.433c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.433 2.082-5.005z"></path></svg>
+                    <span class="text-xs">Liked</span>
+                </div>
+                <p id="dashKpiLiked" class="text-2xl font-bold text-amber-300 tabular-nums">—</p>
+            </div>
+            <div class="dash-card dash-kpi p-4">
+                <div class="flex items-center gap-2 mb-2 text-sky-300/80">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
+                    <span class="text-xs">Watched</span>
+                </div>
+                <p id="dashKpiWatched" class="text-2xl font-bold text-sky-300 tabular-nums">—</p>
+            </div>
+            <div class="dash-card dash-kpi p-4">
+                <div class="flex items-center gap-2 mb-2 text-emerald-300/80">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z"></path></svg>
+                    <span class="text-xs">Catalogs</span>
+                </div>
+                <p id="dashKpiCatalogs" class="text-2xl font-bold text-emerald-300 tabular-nums">—</p>
+            </div>
+        </div>
+
+        <!-- Preferences -->
+        <div class="dash-card p-6">
+            <h3 class="text-sm font-medium text-slate-400 uppercase tracking-wider mb-4">Preferences</h3>
+            <div id="dashSettings" class="grid grid-cols-2 sm:grid-cols-4 gap-4 text-sm"></div>
+        </div>
+
+        <!-- Taste profile -->
+        <div class="dash-card p-6">
+            <div class="flex items-center justify-between mb-4">
+                <h3 class="text-sm font-medium text-slate-400 uppercase tracking-wider">Your taste profile</h3>
+                <div class="flex gap-1 text-xs">
+                    <button type="button" data-ct="movie"
+                        class="dashProfileTab px-3 py-1 rounded-lg border border-slate-700 text-slate-300 transition-colors">Movies</button>
+                    <button type="button" data-ct="series"
+                        class="dashProfileTab px-3 py-1 rounded-lg border border-slate-700 text-slate-300 transition-colors">Series</button>
+                </div>
+            </div>
+            <div id="dashProfileBody"></div>
+        </div>
+
+        <!-- Catalogs (live previews) -->
+        <div class="dash-card p-6">
+            <div class="flex items-center justify-between mb-4 gap-3 flex-wrap">
+                <h3 class="text-sm font-medium text-slate-400 uppercase tracking-wider">Your catalogs</h3>
+                <div class="flex gap-1 text-xs">
+                    <button type="button" data-filter="all"
+                        class="dashCatFilter px-3 py-1 rounded-lg border border-slate-700 text-slate-300 transition-colors">All</button>
+                    <button type="button" data-filter="movie"
+                        class="dashCatFilter px-3 py-1 rounded-lg border border-slate-700 text-slate-300 transition-colors">Movies</button>
+                    <button type="button" data-filter="series"
+                        class="dashCatFilter px-3 py-1 rounded-lg border border-slate-700 text-slate-300 transition-colors">Series</button>
+                </div>
+            </div>
+            <div id="dashCatalogRows" class="space-y-7"></div>
+        </div>
+    </div>
+</section>

--- a/app/templates/components/sidebar.html
+++ b/app/templates/components/sidebar.html
@@ -130,6 +130,23 @@
             <span>Save & Install</span>
         </button>
 
+        <!-- Standalone destination, separate from the setup steps above -->
+        <div class="mt-4 pt-4 border-t border-white/10">
+            <p class="px-4 mb-1 text-[11px] font-semibold uppercase tracking-wider text-slate-600">Manage</p>
+            <button id="nav-dashboard"
+                class="nav-item group w-full flex items-center gap-3 px-4 py-3 text-sm font-medium rounded-xl transition-all text-slate-400 hover:text-white hover:bg-neutral-800/50 text-left">
+                <div
+                    class="w-8 h-8 rounded-lg bg-pink-500/10 text-pink-400 flex items-center justify-center border border-pink-400/20 flex-shrink-0 transition-all group-hover:scale-105 group-hover:bg-pink-500/15 group-hover:border-pink-400/30 group-hover:shadow-lg group-hover:shadow-pink-900/10">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6">
+                        </path>
+                    </svg>
+                </div>
+                <span>Dashboard</span>
+            </button>
+        </div>
+
     </nav>
 
     <div class="p-4 md:p-6 mt-auto space-y-4">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -16,6 +16,8 @@
                 {% include "components/section_install.html" %}
             </form>
 
+            {% include "components/section_dashboard.html" %}
+
         </div>
     </main>
 


### PR DESCRIPTION
A new Dashboard nav section, gated by login state, showing a user's install: manifest URL with Open-in-Stremio/web buttons, KPI cards (library/loved/liked/ watched/catalogs), live catalog previews, and taste-profile chips. Backed by GET /{token}/dashboard/data and POST /{token}/dashboard/refresh; the identity endpoint now returns the token so the section loads without a second login. Account install/update/delete remain in the existing Save & Install flow.