### PR TITLE
Fix v1.14.0 Docker build + Unraid template

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -23,6 +23,8 @@ ENV/
 # Documentation
 README.md
 *.md
+# The /changelog endpoint serves this file
+!CHANGELOG.md
 
 # Docker
 Dockerfile

--- a/.env.example
+++ b/.env.example
@@ -15,7 +15,3 @@ REDIS_CONNECTIONS_THRESHOLD=100
 # UPDATER
 AUTO_UPDATE_CATALOGS=True
 CATALOG_REFRESH_INTERVAL_SECONDS=21600 # 6*60*60 every ~6 hours
-
-# AI Catalog name generation
-GEMINI_API_KEY=<your_gemini_api_key>   # Optional
-DEFAULT_GEMINI_MODEL="gemma-3-27b-it"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,21 +1,12 @@
 # Changelog
 
-## Unreleased
-
-### Added
-
-- Unraid template at `unraid/watchly.xml`, installable via the template URL or by adding the repo under Template Repositories (#154).
-
-### Fixed
-
-- Dropped the stale `GEMINI_API_KEY`/`DEFAULT_GEMINI_MODEL` server env vars from `.env.example` and the README — LLM row naming is configured per user on the configure page.
-
 ## 1.14.0 - 2026-09-01
 
 ### Added
 
 - `ALLOW_SIGNUPS` setting: set it to `False` to lock a public instance to existing accounts. New signups get a 403 and the configure page shows a notice; existing users keep full access (#146).
 - The version badge on the configure page opens a changelog popup, with a link to the GitHub releases page.
+- Unraid template at `unraid/watchly.xml`, installable via the template URL or by adding the repo under Template Repositories (#154).
 
 ### Changed
 
@@ -26,6 +17,8 @@
 
 - Provider logos on the accounts page are proper brand marks inlined into the page; the hot-linked Stremio logo had gone 404.
 - Static assets are served with `no-cache` so deploys reach browsers that cached old bundles.
+- The Docker build no longer fails on `COPY CHANGELOG.md` — `.dockerignore`'s `*.md` rule was excluding the file the `/changelog` endpoint serves.
+- Dropped the stale `GEMINI_API_KEY`/`DEFAULT_GEMINI_MODEL` server env vars from `.env.example` and the README — LLM row naming is configured per user on the configure page.
 
 ## 1.13.1 - 2026-08-25 (Sagarmatha)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Unraid template at `unraid/watchly.xml`, installable via the template URL or by adding the repo under Template Repositories (#154).
+
+### Fixed
+
+- Dropped the stale `GEMINI_API_KEY`/`DEFAULT_GEMINI_MODEL` server env vars from `.env.example` and the README — LLM row naming is configured per user on the configure page.
+
 ## 1.14.0 - 2026-09-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Everything is configured through a web page; you paste the resulting manifest UR
 - [Personalization](#personalization)
 - [Screenshots](#screenshots)
 - [Installation (Docker)](#installation-docker)
+- [Unraid](#unraid)
 - [Configuration reference](#configuration-reference)
 - [Optional integrations](#optional-integrations)
 - [Development](#development)
@@ -134,12 +135,11 @@ Docker is the recommended way to self-host. Watchly requires a **Redis** instanc
    # Redis (matches the compose service name)
    REDIS_URL=redis://redis:6379/0
 
-   # Optional — enable Trakt / Simkl / AI naming (see "Optional integrations")
+   # Optional — enable Trakt / Simkl (see "Optional integrations")
    # TRAKT_CLIENT_ID=
    # TRAKT_CLIENT_SECRET=
    # SIMKL_CLIENT_ID=
    # SIMKL_CLIENT_SECRET=
-   # GEMINI_API_KEY=
    ```
 
    `HOST_NAME` must be the public URL where the addon is reachable. It is used to build OAuth callback URLs and the manifest URL, so it has to match what Stremio (and Trakt/Simkl) will see.
@@ -152,6 +152,18 @@ Docker is the recommended way to self-host. Watchly requires a **Redis** instanc
 
 4. **Configure and install:**
    Open `http://localhost:8000/configure` (or your `HOST_NAME`), connect a history source, pick your catalogs, and paste the generated manifest URL into Stremio.
+
+### Unraid
+
+A Community Applications-style template lives at [`unraid/watchly.xml`](unraid/watchly.xml).
+
+1. Install **Redis** from Community Applications (any Redis container works).
+2. On the **Docker** tab, click **Add Container**, switch to advanced view, and set the template URL to
+   `https://raw.githubusercontent.com/TimilsinaBimal/Watchly/main/unraid/watchly.xml` — or add
+   `https://github.com/TimilsinaBimal/Watchly` under *Template Repositories* and pick **Watchly** from the template list.
+3. Fill in the required fields: TMDB API key, a long random token salt, the Redis URL from step 1
+   (e.g. `redis://YOUR-UNRAID-IP:6379/0`), and the host name your Stremio clients will reach the addon on.
+4. Start the container and open the WebUI to configure your catalogs.
 
 ## Configuration reference
 
@@ -180,8 +192,6 @@ All settings are environment variables. Only the first three are strictly requir
 | --- | --- | --- |
 | `TRAKT_CLIENT_ID` / `TRAKT_CLIENT_SECRET` | — | Trakt OAuth app credentials; enable Trakt as a history source. |
 | `SIMKL_CLIENT_ID` / `SIMKL_CLIENT_SECRET` | — | Simkl OAuth app credentials; enable Simkl as a history source. |
-| `GEMINI_API_KEY` | — | Enables AI-generated, Netflix-style names for the dynamic genre/keyword rows. |
-| `DEFAULT_GEMINI_MODEL` | `gemma-4-26b-a4b-it` | Gemini model used for row naming. |
 
 ### Tuning & behavior
 
@@ -199,6 +209,7 @@ All settings are environment variables. Only the first three are strictly requir
 | `RECOMMENDATION_SOURCE_ITEMS_LIMIT` | `10` | Number of library items used to seed recommendations. |
 | `LIBRARY_ITEMS_LIMIT` | `20` | Library item cap used in parts of the pipeline. |
 | `ANNOUNCEMENT_HTML` | `""` | Optional HTML banner shown on the configure page. |
+| `ALLOW_SIGNUPS` | `true` | Set to `false` to lock the instance to existing accounts; new signups are rejected. |
 
 ## Optional integrations
 
@@ -206,7 +217,7 @@ These are only needed if you want the corresponding feature; Watchly runs fine w
 
 - **Trakt** — create an API app at [trakt.tv/oauth/applications](https://trakt.tv/oauth/applications). Set the redirect URI to `HOST_NAME/auth/trakt/callback` and put the client ID/secret in `TRAKT_CLIENT_ID` / `TRAKT_CLIENT_SECRET`.
 - **Simkl** — create an app at [simkl.com/settings/developer](https://simkl.com/settings/developer). Set the redirect URI to `HOST_NAME/auth/simkl/callback` and put the credentials in `SIMKL_CLIENT_ID` / `SIMKL_CLIENT_SECRET`.
-- **Gemini** — get a key from [Google AI Studio](https://aistudio.google.com/) and set `GEMINI_API_KEY` to enable AI-named dynamic rows. Without it, rows fall back to deterministic names.
+- **AI-named rows** — users configure an LLM provider (Gemini, OpenAI, Anthropic, or OpenRouter) with their own API key on the configure page; no server config required. Without one, rows fall back to deterministic names.
 - **Poster ratings (RPDB)** — users enter their own [RatingPosterDB](https://ratingposterdb.com/) key on the configure page; no server config required.
 
 ## Development

--- a/unraid/watchly.xml
+++ b/unraid/watchly.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>Watchly</Name>
+  <Repository>ghcr.io/timilsinabimal/watchly:latest</Repository>
+  <Registry>https://ghcr.io/timilsinabimal/watchly</Registry>
+  <Network>bridge</Network>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Project>https://github.com/TimilsinaBimal/Watchly</Project>
+  <Support>https://github.com/TimilsinaBimal/Watchly/issues</Support>
+  <TemplateURL>https://raw.githubusercontent.com/TimilsinaBimal/Watchly/main/unraid/watchly.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/TimilsinaBimal/Watchly/main/app/static/logo.png</Icon>
+  <Category>MediaApp:Video Tools:</Category>
+  <WebUI>http://[IP]:[PORT:8000]/configure</WebUI>
+  <DonateText>Support the developer</DonateText>
+  <DonateLink>https://buymemomo.com/timilsinabimal</DonateLink>
+  <Overview>
+    Watchly is a personalized recommendation engine for Stremio and Nuvio. It builds catalogs like "Top Picks for You" and "Because you loved ..." from your Stremio, Trakt, or Simkl watch history.
+
+    REQUIRES a separate Redis container: install Redis from Community Applications first, then point Redis URL at it (e.g. redis://YOUR-UNRAID-IP:6379/0).
+
+    You also need a free TMDB API key (https://www.themoviedb.org/settings/api) and a long random Token Salt (e.g. from: openssl rand -hex 32). Host Name must be the URL where the addon is reachable from your Stremio clients.
+
+    After starting the container, open the WebUI to connect an account, pick catalogs, and get your addon manifest URL.
+  </Overview>
+  <Config Name="WebUI Port" Target="8000" Default="8000" Mode="tcp" Description="Port for the configure page and the Stremio addon endpoints." Type="Port" Display="always" Required="true" Mask="false">8000</Config>
+  <Config Name="TMDB API Key" Target="TMDB_API_KEY" Default="" Description="TMDB API key, free at https://www.themoviedb.org/settings/api" Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="Token Salt" Target="TOKEN_SALT" Default="" Description="Long random secret used to encrypt stored credentials. Generate once (e.g. openssl rand -hex 32) and never change it, or existing user tokens become unreadable." Type="Variable" Display="always" Required="true" Mask="true"/>
+  <Config Name="Redis URL" Target="REDIS_URL" Default="redis://YOUR-UNRAID-IP:6379/0" Description="URL of your Redis container. Install Redis from Community Applications and use its IP/port here." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Host Name" Target="HOST_NAME" Default="http://YOUR-UNRAID-IP:8000" Description="URL where the addon is reachable from your Stremio clients (used in the manifest and OAuth callback URLs). Use your public HTTPS URL if you expose Watchly outside your LAN." Type="Variable" Display="always" Required="true" Mask="false"/>
+  <Config Name="Allow Signups" Target="ALLOW_SIGNUPS" Default="True" Description="Set to False to lock this instance to existing accounts: no new users can sign up." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Trakt Client ID" Target="TRAKT_CLIENT_ID" Default="" Description="Optional. Trakt API app client id, to let users connect Trakt accounts." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Trakt Client Secret" Target="TRAKT_CLIENT_SECRET" Default="" Description="Optional. Trakt API app client secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+  <Config Name="Simkl Client ID" Target="SIMKL_CLIENT_ID" Default="" Description="Optional. Simkl API app client id, to let users connect Simkl accounts." Type="Variable" Display="advanced" Required="false" Mask="false"/>
+  <Config Name="Simkl Client Secret" Target="SIMKL_CLIENT_SECRET" Default="" Description="Optional. Simkl API app client secret." Type="Variable" Display="advanced" Required="false" Mask="true"/>
+</Container>


### PR DESCRIPTION
Unblocks the release chain on `main`: the v1.14.0 image build failed because `.dockerignore`'s `*.md` rule excluded `CHANGELOG.md`, which the Dockerfile now copies for the `/changelog` endpoint. Fixed with a `!CHANGELOG.md` negation, verified locally with a test build.

Also carries the Unraid container template (`unraid/watchly.xml` + README install steps) and drops the stale `GEMINI_API_KEY`/`DEFAULT_GEMINI_MODEL` server env vars from the docs (nothing reads them — LLM naming is per-user via the configure page). Closes #154

Since v1.14.0 never released, its changelog section now includes these items; merging re-runs the chain and ships v1.14.0 properly.

## Testing
- `docker build` with a minimal Dockerfile copying `CHANGELOG.md` — no CopyIgnoredFile warning, COPY succeeds.
- 126 tests pass; template XML parses and every env var in it verified against `config.py`.