### PR TITLE
feat(catalogs): configurable row count for the item catalog (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- The "Because you watched/loved" catalog can emit up to 3 rows per content type, each seeded by a different recent title. A rows stepper on the configure page sets the count (#137).
+
+### Fixed
+
+- A dynamic row slot the manifest no longer defines serves an empty row instead of recommendations for whatever TMDB id the slot number happened to match.
+
 ## 1.14.0 - 2026-09-01
 
 ### Added

--- a/app/core/app.py
+++ b/app/core/app.py
@@ -15,7 +15,7 @@ from app.api.router import api_router
 from app.core.errors import register_exception_handlers
 from app.core.logging import configure_logging, register_request_id_middleware
 from app.core.security import STORED_SECRET_SENTINEL
-from app.core.settings import get_current_year, get_default_catalogs_for_frontend, get_default_year_range
+from app.core.settings import MAX_ITEM_ROWS, get_current_year, get_default_catalogs_for_frontend, get_default_year_range
 from app.services.redis_service import redis_service
 from app.services.tmdb.genre import movie_genres, series_genres
 from app.services.token_store import token_store
@@ -125,6 +125,7 @@ async def configure_page(request: Request, _token: str | None = None):
         announcement_html=settings.ANNOUNCEMENT_HTML or "",
         languages=languages,
         default_catalogs=default_catalogs,
+        max_item_rows=MAX_ITEM_ROWS,
         current_year=get_current_year(),
         year_range_defaults=year_range_defaults,
         stored_secret_sentinel=STORED_SECRET_SENTINEL,

--- a/app/core/settings.py
+++ b/app/core/settings.py
@@ -6,6 +6,10 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from app.services.poster_ratings.factory import PosterProvider
 
+# The seed pool is the 3 most-recent loved + 3 most-recent watched items. Capped
+# below the pool so a home screen is never mostly "Because you watched" rows.
+MAX_ITEM_ROWS = 3
+
 
 class CatalogConfig(BaseModel):
     id: str  # "watchly.rec", "watchly.theme", "watchly.item"
@@ -15,6 +19,9 @@ class CatalogConfig(BaseModel):
     enabled_series: bool = Field(default=True, description="Enable series catalog for this configuration")
     display_at_home: bool = Field(default=True, description="Display this catalog on home page")
     shuffle: bool = Field(default=False, description="Randomize order of items in this catalog")
+    rows: int = Field(
+        default=1, ge=1, le=MAX_ITEM_ROWS, description="Rows per content type; only watchly.item emits more than one"
+    )
 
     @field_validator("name", mode="before")
     @classmethod
@@ -126,10 +133,10 @@ class UserSettings(BaseModel):
 CATALOG_DESCRIPTIONS = {
     "watchly.rec": "Personalized recommendations based on your watch history, library and your reactions.",
     "watchly.item": (
-        "Recommends items similar to one you recently watched or loved. The seed is picked uniformly at random"
-        " from a pool of your 3 most-recent loved items + your 3 most-recent watched items. The catalog title"
-        " becomes 'Because you loved <title>' or 'Because you watched <title>' depending on which bucket the"
-        " seed came from."
+        "Recommends items similar to one you recently watched or loved. Each row's seed is picked at random"
+        " from a pool of your 3 most-recent loved items + your 3 most-recent watched items, with no seed"
+        " repeated across rows. The catalog title becomes 'Because you loved <title>' or 'Because you watched"
+        " <title>' depending on which bucket the seed came from."
     ),
     "watchly.creators": (
         "Recommends items from your recurring directors and lead actors — those who appear across multiple"
@@ -222,6 +229,7 @@ def get_default_catalogs_for_frontend() -> list[dict]:
                 "enabledSeries": catalog.enabled_series,
                 "display_at_home": catalog.display_at_home,
                 "shuffle": catalog.shuffle,
+                "rows": catalog.rows,
                 "description": CATALOG_DESCRIPTIONS.get(catalog.id, ""),
             }
         )

--- a/app/services/catalog_definitions.py
+++ b/app/services/catalog_definitions.py
@@ -358,12 +358,12 @@ class DynamicCatalogService:
         item_config: Any,
         row_slots: dict[str, dict[str, str]],
     ) -> None:
-        """Emit one item-based row per content type.
+        """Emit `item_config.rows` item-based rows per content type.
 
         Seed selection: take the 3 most-recent loved items and the 3 most-recent
-        watched items, combine, and pick uniformly at random. The label
+        watched items, combine, and sample one distinct seed per row. The label
         ("Because you loved X" vs "Because you watched X") follows the bucket
-        the chosen seed came from. The configured `name` is for the FE display
+        each seed came from. The configured `name` is for the FE display
         only — the served catalog title is always one of the two dynamic
         labels — so the configure page disables renaming this catalog.
         """
@@ -390,13 +390,13 @@ class DynamicCatalogService:
         if not candidates:
             return
 
-        seed, seed_is_loved = random.choice(candidates)
-        label = "Because you loved" if seed_is_loved else "Because you watched"
-
         display_at_home = getattr(item_config, "display_at_home", True)
-        entry = self.build_catalog_entry(seed, label, "watchly.item", display_at_home)
-        # The seed is re-randomised on every rebuild, so keeping it in the id gave
-        # this row a new cache key each time. It lives in the slot map instead.
-        row_slots.setdefault(content_type, {})["item.1"] = entry["id"].replace("watchly.item.", "", 1)
-        entry["id"] = "watchly.item.1"
-        catalogs.append(entry)
+        seeds = random.sample(candidates, k=min(item_config.rows, len(candidates)))
+        for slot, (seed, seed_is_loved) in enumerate(seeds, start=1):
+            label = "Because you loved" if seed_is_loved else "Because you watched"
+            entry = self.build_catalog_entry(seed, label, "watchly.item", display_at_home)
+            # The seed is re-randomised on every rebuild, so keeping it in the id gave
+            # this row a new cache key each time. It lives in the slot map instead.
+            row_slots.setdefault(content_type, {})[f"item.{slot}"] = entry["id"].replace("watchly.item.", "", 1)
+            entry["id"] = f"watchly.item.{slot}"
+            catalogs.append(entry)

--- a/app/services/recommendation/catalog_service.py
+++ b/app/services/recommendation/catalog_service.py
@@ -161,6 +161,12 @@ class CatalogService:
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Build fresh catalog content using the loaded user context."""
         try:
+            # Resolved only for building. The cache key stays the slot id the client
+            # asked for, which is the whole point: it survives a definition change.
+            resolved_id = await self._resolve_slot(ctx.token, content_type, catalog_id)
+            if resolved_id is None:
+                return {"metas": []}, headers
+
             services = self._initialize_services(ctx.user_settings)
             profile_service: ProfileService = services["profile"]
 
@@ -193,10 +199,8 @@ class CatalogService:
                     user_settings=ctx.user_settings,
                 )
 
-            # Resolved only for building. The cache key stays the slot id the client
-            # asked for, which is the whole point: it survives a definition change.
             recommendations = await self._get_recommendations(
-                catalog_id=await self._resolve_slot(ctx.token, content_type, catalog_id),
+                catalog_id=resolved_id,
                 content_type=content_type,
                 services=services,
                 profile=profile,
@@ -301,7 +305,7 @@ class CatalogService:
             return []
 
     @staticmethod
-    async def _resolve_slot(token: str, content_type: str, catalog_id: str) -> str:
+    async def _resolve_slot(token: str, content_type: str, catalog_id: str) -> str | None:
         """Expand a slot id into the row definition it currently points at.
 
         Served ids are stable slots (`watchly.theme.2`) so the cache key never moves
@@ -311,6 +315,10 @@ class CatalogService:
 
         Ids that aren't slots are returned unchanged: manifests installed before this
         carry self-describing ids and Stremio keeps requesting them until it refreshes.
+
+        None means the slot has no definition — the user reduced their row count and
+        the installed client still asks for the dropped slot. Passing the id through
+        instead would hand the item engine a bare "3", which it reads as TMDB id 3.
         """
         match = re.match(r"^watchly\.(theme|item)\.(\d+)$", catalog_id)
         if not match:
@@ -320,7 +328,7 @@ class CatalogService:
         definition = (await user_cache.get_row_map(token, content_type)).get(f"{prefix}.{slot}")
         if not definition:
             logger.warning(f"[{redact_token(token)}] No row definition for {catalog_id} ({content_type})")
-            return catalog_id
+            return None
 
         return f"watchly.{prefix}.{definition}"
 

--- a/app/static/js/modules/auth.js
+++ b/app/static/js/modules/auth.js
@@ -385,6 +385,7 @@ async function fetchIdentity(payload) {
                         if (typeof remote.enabled_series === 'boolean') local.enabledSeries = remote.enabled_series;
                         if (typeof remote.display_at_home === 'boolean') local.display_at_home = remote.display_at_home;
                         if (typeof remote.shuffle === 'boolean') local.shuffle = remote.shuffle;
+                        if (typeof remote.rows === 'number') local.rows = remote.rows;
                     }
                 });
                 if (renderCatalogList) renderCatalogList();

--- a/app/static/js/modules/catalog.js
+++ b/app/static/js/modules/catalog.js
@@ -44,6 +44,8 @@ function createCatalogItem(cat, index) {
     // builds them from the seed bucket ("Because you loved/watched"). Both
     // would discard a user-supplied name, so the rename button is hidden.
     const isRenamable = cat.id !== 'watchly.theme' && cat.id !== 'watchly.item';
+    // Only the item catalog can emit several rows; each gets its own seed.
+    const hasRowCount = cat.id === 'watchly.item';
 
     // Determine active mode for toggle buttons
     const enabledMovie = cat.enabledMovie !== false;
@@ -122,7 +124,7 @@ function createCatalogItem(cat, index) {
                 <div class="flex items-center gap-2 sm:gap-3 mt-2">
                     <div class="catalog-desc text-xs text-slate-400 flex-grow">${escapeHtml(cat.description || '')}</div>
                 </div>
-                <div class="mt-3">
+                <div class="mt-3 flex flex-wrap items-center gap-3">
             <div class="inline-flex items-center bg-neutral-900/60 border border-white/10 rounded-xl p-1 backdrop-blur-sm" role="group" aria-label="Content type selection">
                 <button type="button" class="catalog-type-btn px-4 py-2 text-sm font-medium rounded-lg transition-all outline-none focus:outline-none ${activeMode === 'both' ? 'bg-white/10 text-white border border-white/20 shadow-sm' : 'text-slate-400 hover:text-white hover:bg-white/5 border border-transparent'}" data-catalog-id="${cat.id}" data-mode="both">
                     Both
@@ -134,6 +136,12 @@ function createCatalogItem(cat, index) {
                     Series
                 </button>
             </div>
+            ${hasRowCount ? `<div class="inline-flex items-center bg-neutral-900/60 border border-white/10 rounded-xl p-1 backdrop-blur-sm" role="group" aria-label="Number of rows">
+                <span class="px-3 text-sm text-slate-400">Rows</span>
+                <button type="button" class="rows-btn px-3 py-2 text-sm font-medium rounded-lg text-slate-400 hover:text-white hover:bg-white/5 transition-all disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-not-allowed" data-step="-1" aria-label="Fewer rows" ${cat.rows <= 1 ? 'disabled' : ''}>&minus;</button>
+                <span class="rows-value w-6 text-center text-sm font-medium text-white">${cat.rows}</span>
+                <button type="button" class="rows-btn px-3 py-2 text-sm font-medium rounded-lg text-slate-400 hover:text-white hover:bg-white/5 transition-all disabled:opacity-30 disabled:hover:bg-transparent disabled:cursor-not-allowed" data-step="1" aria-label="More rows" ${cat.rows >= window.MAX_ITEM_ROWS ? 'disabled' : ''}>+</button>
+            </div>` : ''}
         </div>
     `;
 
@@ -223,6 +231,18 @@ function createCatalogItem(cat, index) {
             updateShuffleButton(shuffleBtn, cat.shuffle);
         });
     }
+
+    item.querySelectorAll('.rows-btn').forEach(btn => {
+        btn.addEventListener('click', (e) => {
+            e.preventDefault();
+            const next = cat.rows + Number(btn.dataset.step);
+            if (next < 1 || next > window.MAX_ITEM_ROWS) return;
+            cat.rows = next;
+            item.querySelector('.rows-value').textContent = String(next);
+            item.querySelector('.rows-btn[data-step="-1"]').disabled = next <= 1;
+            item.querySelector('.rows-btn[data-step="1"]').disabled = next >= window.MAX_ITEM_ROWS;
+        });
+    });
 
     return item;
 }

--- a/app/static/js/modules/form.js
+++ b/app/static/js/modules/form.js
@@ -77,7 +77,8 @@ function getRequestPayload() {
             enabled_movie: catalog.enabledMovie !== false,
             enabled_series: catalog.enabledSeries !== false,
             display_at_home: catalog.display_at_home !== false,
-            shuffle: catalog.shuffle === true
+            shuffle: catalog.shuffle === true,
+            rows: catalog.rows
         })),
         language: languageSelect?.value || 'english',
         year_min: parseInt(document.getElementById('yearMin')?.value || String(YEAR_RANGE_DEFAULTS.min), 10),

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -292,6 +292,7 @@
     <script>
         // Default catalog configurations from backend
         window.DEFAULT_CATALOGS = {{ default_catalogs | tojson }};
+        window.MAX_ITEM_ROWS = {{ max_item_rows | tojson }};
         window.YEAR_RANGE_DEFAULTS = {{ year_range_defaults | tojson }};
 
         // Placeholder that stands in for a saved API key the server won't send back

--- a/tests/test_configure_page.py
+++ b/tests/test_configure_page.py
@@ -23,6 +23,8 @@ def test_configure_page_bootstraps_current_year_and_year_defaults(monkeypatch):
     assert response.status_code == 200
     html = response.text
     assert 'window.YEAR_RANGE_DEFAULTS = {"min": 1970, "max": ' in html
+    assert "window.MAX_ITEM_ROWS = 3;" in html
+    assert '"rows": 1' in html
     assert 'id="yearMin" min="1970"' in html
     assert 'id="yearMax" min="1970"' in html
 

--- a/tests/test_row_slots.py
+++ b/tests/test_row_slots.py
@@ -86,7 +86,11 @@ def test_non_dynamic_ids_pass_through(fake_redis):
     assert resolve("watchly.creators") == "watchly.creators"
 
 
-def test_unknown_slot_is_left_alone(fake_redis):
-    """No stored definition means the row can't be built; returning the id unchanged
-    lets the normal routing produce an empty row rather than raising."""
-    assert resolve("watchly.theme.7") == "watchly.theme.7"
+def test_unknown_slot_resolves_to_nothing(fake_redis):
+    """A user who drops from 3 item rows to 1 still has a client asking for
+    watchly.item.3. Passing the id through would make the item engine read the
+    bare "3" as TMDB id 3, so an undefined slot must resolve to None instead."""
+    asyncio.run(user_cache.set_row_map(TOKEN, "movie", {"item.1": "tt0468569"}))
+
+    assert resolve("watchly.item.3") is None
+    assert resolve("watchly.theme.7") is None

--- a/tests/test_row_slots.py
+++ b/tests/test_row_slots.py
@@ -1,7 +1,11 @@
 import asyncio
 
 import pytest
+from pydantic import ValidationError
 
+from app.core.settings import MAX_ITEM_ROWS, CatalogConfig
+from app.models.library import LibraryCollection, StremioLibraryItem
+from app.services.catalog_definitions import DynamicCatalogService
 from app.services.recommendation.catalog_service import catalog_service
 from app.services.user_cache import user_cache
 
@@ -94,3 +98,54 @@ def test_unknown_slot_resolves_to_nothing(fake_redis):
 
     assert resolve("watchly.item.3") is None
     assert resolve("watchly.theme.7") is None
+
+
+def library_item(item_id: str, loved: bool, mtime: str) -> StremioLibraryItem:
+    return StremioLibraryItem(
+        _id=item_id, type="movie", name=item_id.upper(), temp=False, removed=False, _is_loved=loved, _mtime=mtime
+    )
+
+
+def item_rows(rows: int, loved: int, watched: int) -> tuple[list[dict], dict[str, dict[str, str]]]:
+    library = LibraryCollection(
+        loved=[library_item(f"tt{n}", True, f"2026-01-{n:02d}T00:00:00Z") for n in range(1, loved + 1)],
+        watched=[library_item(f"tt{n}", False, f"2026-02-{n:02d}T00:00:00Z") for n in range(11, 11 + watched)],
+    )
+    config = CatalogConfig(id="watchly.item", rows=rows)
+    catalogs: list[dict] = []
+    row_slots: dict[str, dict[str, str]] = {}
+    service = DynamicCatalogService()
+    asyncio.run(service._add_item_based_rows(catalogs, library, "movie", config, row_slots))
+    return catalogs, row_slots
+
+
+def test_one_row_by_default():
+    catalogs, row_slots = item_rows(rows=1, loved=3, watched=3)
+
+    assert [c["id"] for c in catalogs] == ["watchly.item.1"]
+    assert set(row_slots["movie"]) == {"item.1"}
+
+
+def test_each_row_gets_its_own_slot_and_a_distinct_seed():
+    catalogs, row_slots = item_rows(rows=3, loved=3, watched=3)
+
+    assert [c["id"] for c in catalogs] == ["watchly.item.1", "watchly.item.2", "watchly.item.3"]
+    seeds = list(row_slots["movie"].values())
+    assert len(set(seeds)) == 3
+    for catalog, seed in zip(catalogs, seeds):
+        expected = "Because you loved" if seed in {"tt1", "tt2", "tt3"} else "Because you watched"
+        assert catalog["name"] == f"{expected} {seed.upper()}"
+
+
+def test_rows_are_capped_by_the_candidate_pool():
+    catalogs, row_slots = item_rows(rows=3, loved=1, watched=1)
+
+    assert [c["id"] for c in catalogs] == ["watchly.item.1", "watchly.item.2"]
+    assert set(row_slots["movie"].values()) == {"tt1", "tt11"}
+
+
+def test_row_count_is_bounded():
+    with pytest.raises(ValidationError):
+        CatalogConfig(id="watchly.item", rows=0)
+    with pytest.raises(ValidationError):
+        CatalogConfig(id="watchly.item", rows=MAX_ITEM_ROWS + 1)


### PR DESCRIPTION
## What

Addresses #137. The "Because you watched/loved" catalog can now emit 1 to 3 rows per content type. Each row is a stable slot (`watchly.item.1..N`) seeded by a distinct title sampled from the 3 most-recent loved + 3 most-recent watched items. The configure page shows a rows stepper on that card and round-trips the value through save and load.

The other half of the request, dropping the Creators row, already works through that catalog's enable toggle.

## Fix included as its own commit

An unresolved slot id used to pass through the resolver unchanged, so a client still asking for `watchly.item.3` after the user dropped to 1 row would hand the item engine the bare id `3`, which `resolve_tmdb_id` reads as TMDB id 3. The resolver now returns `None` and the build short-circuits to an empty row. This was latent before: a missing row map would have sent `watchly.item.1` down the same path.

## Changes

- `CatalogConfig.rows` (`ge=1, le=MAX_ITEM_ROWS`), exported to the frontend with the other defaults; `MAX_ITEM_ROWS` reaches the page as `window.MAX_ITEM_ROWS`.
- `_add_item_based_rows` samples `rows` distinct seeds with `random.sample` and emits one slot each. Fewer candidates than rows means fewer rows.
- Rows stepper on the item card in `catalog.js`; `form.js` sends `rows`; `auth.js` loads it back.
- `CHANGELOG.md` gets an `Unreleased` section. No version bump.

## Verification

- `uv run --with pytest python -m pytest tests/ -q`: 130 passed.
- New tests in `tests/test_row_slots.py` cover default row count, distinct seeds per slot, capping by the candidate pool, the bounded field, and the unresolved-slot fix. `tests/test_configure_page.py` pins the template contract.
- `pre-commit` passes on all changed files; the JS modules pass `node --check`.
- Not verified: the stepper was not opened in a browser. Worth a quick look on the configure page before merging.

## Noted, not changed here

- `should_shuffle` matches the exact catalog id, so the shuffle toggle never applies to `watchly.item.N` or `watchly.theme.N` rows.
- The Creators 404 is swallowed by the catch-all in `_build_catalog` and served as an empty row.